### PR TITLE
fix: cleanup of plots

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,11 +22,11 @@ website:
       - text: "Peer Review"
         menu:
           - text: Current Review Status
-            href: peer-review/current-peer-review.qmd
+            href: peer-review/current-review-status.qmd
           - text: Over Time 
             href: peer-review/reviews-over-time.qmd
-          - text: Peer review timing
-            href: peer-review/review-timing.qmd
+          - text: Peer review trends
+            href: peer-review/review-trends.qmd
       - text: "Contributors"
         href: contributors.qmd
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,12 +1,29 @@
 ---
 title: Welcome to pyOpenSci Metrics Dashboards
-date: "2025-02-13"
-categories: 
-  - peer review
 jupyter: python3
 ---
 
-# Welcome to pyOpenSci's metrics dashboard
+## Welcome to pyOpenSci's metrics dashboard
 
-If you are looking to contribute, then you may want to checkout
-our README file.
+If you are looking to contribute, checkout our [README file](https://www.github.com//pyopensci/metrics/README.md).
+
+::: {.grid }
+
+::: {.g-col-6 style="border: 1px solid #cccccc; padding: 10px"}
+
+**Peer Review Status and History Data**
+
+* [Peer Review Status Dashboard](/peer-review/current-review-status.html)
+* [Peer Review Over Time](/peer-review/reviews-over-time.html)
+* [Peer Review Trends](/peer-review/review-trends.html)
+
+:::
+
+::: {.g-col-6 style="border: 1px solid #cccccc; padding: 10px"}
+**Contributor Data through Sprints and adhoc**
+
+* [Contributor Data](contributors.html)
+:::
+
+
+:::

--- a/peer-review/current-review-status.qmd
+++ b/peer-review/current-review-status.qmd
@@ -5,7 +5,7 @@ execute:
   echo: false
 ---
 
-# Current open reviews 
+## Current open reviews 
 
 This page overviews the current state of pyOpenSci open peer review submissions. 
 
@@ -50,7 +50,7 @@ label_map = {
         "4/reviews-in-awaiting-changes",
         "5/awaiting-reviewer-response",
     ],
-    "accepted": ["6/pyos-approved", "9/joss-approved"],
+    "accepted-open": ["6/pyOS-approved", "9/joss-approved"],
 }
 
 def get_active_status(labels):
@@ -89,14 +89,14 @@ all_presubmissions = len(presubmissions)
 
 
 ```{python}
-# Open presubmission data
+# Process presubmission data
 open_presubmissions = presubmissions[presubmissions["Date Closed"].isna()]
 today = datetime.now(timezone.utc)
 open_presubmissions["days_open"] = (
     today - open_presubmissions["Date Opened"]
 ).dt.days
 open_presubmissions["Date Opened"] = open_presubmissions["Date Opened"].dt.date
-open_presubmissions["Date Opened"] = open_presubmissions["Last Comment"].dt.date
+open_presubmissions["Last Comment"] = open_presubmissions["Last Comment"].dt.date
 open_presubmissions.reset_index(drop=True, inplace=True)
 
 ```
@@ -130,16 +130,14 @@ total_open = len(open_reviews)
 
 ```
 
-## Table showing current open reviews 
+
 ```{python}
 #| echo: false
 
 # Create active status column
 open_reviews["active_status"] = open_reviews["labels"].apply(get_active_status)
-show(open_reviews)
+
 ```
-
-
 
 ```{python}
 #| echo: false
@@ -160,12 +158,6 @@ seeking_editor = open_reviews[open_reviews["active_status"]=="seeking editor"]
 seeking_editor_count = len(seeking_editor)
 ```
 
-pyOpenSci quick stats:
-
-* **`{python} total_open`** reviews are open
-our open software peer review process 
-* **`{python} len(open_presubmissions)`** open pre-submission inquiries.
-* **`{python} seeking_editor_count`** packages need editors
 
 ## Current review status 
 
@@ -194,64 +186,73 @@ bar_chart.show()
 ```
 
 
-## Current open reviews & total days open
+### All open reviews 
 
-pyOpenSci currently has `{python} total_open` total open submissions.
+pyOpenSci currently has **`{python} total_open`** open
+reviews and **`{python} len(open_presubmissions)`** open pre-submission inquiries.
 
 ```{python}
-seeking_editor = open_reviews[
-    open_reviews["labels"].str.contains("0/seeking-editor", na=False)
-].copy()
-seeking_editor.drop(
-    columns=[ "labels", "status"], inplace=True
-)
-seeking_editor.reset_index(drop=True, inplace=True)
-seeking_editor.style.set_properties(
-    **{"text-align": "left", "white-space": "normal"}
-)
-show(seeking_editor)
+#| echo: false
+# status_df = open_reviews.drop(columns=["status","labels", "Categories"])
+label_order = ["Name","active_status", "Date Opened", "Days Open", "Last Comment", "Last User to Comment", "editor", "eic", "Issue"]
+status_df = open_reviews[label_order]
+status_df.reset_index(drop=True, inplace=True)
+# Create active status column
+show(status_df)
 ```
 
-## Packages that need editors
 
-The packages below need an editor before the review can begin.
+## Editors needed
+
+**`{python} seeking_editor_count`** packages, listed below, need editors.
 
 ```{python}
-seeking_editor = open_reviews[
-    open_reviews["labels"].str.contains("0/seeking-editor", na=False)
-].copy()
-seeking_editor.drop(
-    columns=[ "labels", "status"], inplace=True
-)
+seeking_editor = status_df[status_df["active_status"]=="seeking editor"]
 seeking_editor.reset_index(drop=True, inplace=True)
 show(seeking_editor)
 ```
 
 
-## Packages that need reviewers
+## Reviewers needed
+
 
 ```{python}
 
-seeking_reviewers = open_reviews[
-    open_reviews["active_status"] == "seeking reviewers"]
-show(seeking_reviewers)
-```
+seeking_reviewers = status_df[
+    status_df["active_status"] == "seeking reviewers"]
+seeking_reviewers.reset_index(drop=True, inplace=True)
 
+```
 `{python} len(seeking_reviewers)` package(s) currently needs reviewers. 
 
 
-## Currently open software presubmission inquiries
+```{python}
+show(seeking_reviewers)
+```
 
-There are currently **`{python} len(open_presubmissions)`** open presubmission inquiries.
+
+## Open review presubmission inquiries
+
+There are currently **`{python} len(open_presubmissions)`** open presubmission inquiries. The current EiC handles all presubmission inquiries,
 
 There are **`{python} len(open_presubmissions)` presubmission requests** currently open.
 
 ```{python}
-show(open_presubmissions)
+# TODO: add days open to presubs too
+open_presubmissions.dtypes
+label_order_presub = ["Name",  "Date Opened",  "Last Comment", "Last User to Comment", "eic", "Issue"]
+
+open_presubs_clean = open_presubmissions[label_order_presub]
+```
+
+```{python}
+
+open_presubs_clean.reset_index(drop=True, inplace=True)
+show(open_presubs_clean)
 ```
 
 
-## Editorial team status
+## Editorial team workload
 
 ```{python}
 # Static list of all editors, updated 7/13/2024
@@ -319,6 +320,8 @@ The data below represents all editors over time, not just currently active edito
 :::
 
 ```{python}
+# TODO: make this focus only on current open reviews vs all reviews over time. 
+
 # Get a list of all editors over time that have supported pyOpenSci
 ignore_editors = ["TBD"]
 # ignore lwasser and xmnlab to bring min date to a more recent date
@@ -352,7 +355,12 @@ df["Date"] = pd.to_datetime(df["Year"].astype(str) + "-" + (3 * (df["Quarter"].a
 edits = reviews.rename(columns={"Date Opened": "Date"}).copy()
 ```
 
+
+
 ```{python}
+
+# TODO: If this uses open_reviews it's only showing current load
+# if it uses the reviews df it's showing reviews all time 2019 to present. open_reviews has a slightly different structure
 edits = reviews[["editor", "Name", "Date Opened"]]
 edits = edits.rename(columns={"Date Opened": "Date", "Name":"package_name"})
 edits = edits[edits["editor"] != "TBD"]

--- a/peer-review/review-trends.qmd
+++ b/peer-review/review-trends.qmd
@@ -1,5 +1,5 @@
 ---
-title: pyOpenSci Peer Review Timing
+title: pyOpenSci Peer Review Trends
 date: "2025-02-13"
 categories: 
   - peer review
@@ -8,7 +8,7 @@ execute:
   echo: false
 ---
 
-This is a workflow that colates all GitHub issues associated with our reviews. 
+This is a workflow that collates all GitHub issues associated with our reviews. 
 
 
 ```{python}

--- a/peer-review/reviews-over-time.qmd
+++ b/peer-review/reviews-over-time.qmd
@@ -7,24 +7,6 @@ jupyter: python3
 
 
 ```{python}
-# Sometimes the token doesn't get updated properly in jupyter. 
-# If this happens you can do a few things
-# import os
-# from dotenv import load_dotenv
-
-# load_dotenv()
-
-# print(os.getenv("GITHUB_TOKEN"))
-
-# # Print all envt keys to see what token value is stored
-# for key, value in os. environ.items():
-#     print(f"{key}: {value}")
-
-#in bash use: export GITHUB_TOKEN=valuehere
-```
-
-
-```{python}
 import warnings
 from datetime import datetime
 from pathlib import Path
@@ -104,16 +86,13 @@ presub_open_count = len(presub_count)
 
 ```
 
-## Total scientific Python software submissions by status
-
+## Total scientific Python software review submissions
 
 ```{python}
 review_status_ct = reviews["status"].value_counts().reset_index()
 review_status_ct.rename(columns={"labels": "status"}, inplace=True)
-review_status_ct
+
 ```
-
-
 
 
 ```{python}
@@ -125,24 +104,18 @@ open_reviews = active_open_reviews[active_open_reviews["date_closed"].isna()]
 open_count = len(open_reviews)
 ```
 
-
-
-## Current review status 
-
-The plot below shows the status of our current open and closed reviews. 
-
-A few of these numbers are a bit off (or out of sync with our project board)
-But the numbers right now are close!
+The plot below shows the volume of all reviews over time. 
 
 
 ```{python}
+# TODO: fix this plot so there is enough
 chart = (
     alt.Chart(review_status_ct)
     .mark_bar()
     .encode(
         y=alt.Y(
             "status",
-            title="Review Status",
+            title="",
             sort=[
                 "pre-review",
                 "seeking editor",
@@ -157,7 +130,7 @@ chart = (
             "count",
             axis=alt.Axis(tickCount=5),
             title="Count",
-            scale=alt.Scale(domain=[0, 20]),
+            scale=alt.Scale(domain=[0, 30]),
         ),
         tooltip=[
             alt.Tooltip("status:N", title="Status"),
@@ -167,11 +140,10 @@ chart = (
     .properties(title="Count of Packages by Status", width="container")
 )
 
+
 # Display the chart
 chart.show()
 ```
-
-
 
 
 
@@ -179,26 +151,6 @@ chart.show()
 # This calculates status on currently open reviews
 #open_reviews["status"] = open_reviews["labels"].apply(set_review_status)
 status_counts = open_reviews["status"].value_counts().reset_index()
-```
-
-
-```{python}
-chart = (
-    alt.Chart(status_counts)
-    .mark_bar()
-    .encode(
-        x=alt.X("status"),
-        y="count",
-        tooltip=[
-            alt.Tooltip("status:N", title="Status"),
-            alt.Tooltip("count:Q", title="Count"),
-        ],
-    )
-    .properties(title="Review Status for Current Reviews", width="container")
-)
-
-# Display the chart
-chart.show()
 ```
 
 


### PR DESCRIPTION
This pr cleans up the peer review plots - separating current status data from all-time historical data. 

It also adds a nice landing page with links to direct users who land on the page. 